### PR TITLE
feat: Configure Prisma and NextAuth for MySQL

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,18 @@
+# ----------------------------------------------------
+# 1. TI DB CLOUD CONNECTION STRING (Prisma DATABASE_URL)
+# The format is: mysql://USER:PASSWORD@HOST:PORT/DATABASE?sslaccept=strict
+
+DATABASE_URL="mysql://3v7Quu7GgFUxeVj.root:reySMcqkbmTxf3Ma@gateway01.ap-southeast-1.prod.aws.tidbcloud.com:4000/test?sslaccept=strict"
+
+# NOTE ON SSL: TiDB connections MUST use SSL. Adding `sslaccept=strict`
+# is often enough for local testing, but you might need the CA certificate
+# for production deployment (see Step 3 below).
+
+# ----------------------------------------------------
+# 2. NEXTAUTH SECRETS (Required for Auth)
+
+# Use 'npx auth secret' in your terminal or a random generator for a 32+ character string.
+NEXTAUTH_SECRET="your_long_random_nextauth_secret" 
+
+# Base URL for the NextAuth callback (crucial for local development)
+NEXTAUTH_URL="http://localhost:3000"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,62 @@
+generator client {
+  provider = "prisma-client-js"
+  // previewFeatures = ["driverAdapters"]
+}
+
+datasource db {
+  provider = "mysql"
+  url      = env("DATABASE_URL")
+}
+
+// --- NextAuth Models ---
+model Account {
+  id                 String  @id @default(cuid())
+  userId             String
+  type               String
+  provider           String
+  providerAccountId  String
+  refresh_token      String?  @map("refresh_token")
+  access_token       String?  @map("access_token")
+  expires_at         Int?     @map("expires_at")
+  token_type         String?  @map("token_type")
+  scope              String?
+  id_token           String?  @map("id_token")
+  session_state      String?  @map("session_state")
+
+  user               User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, providerAccountId])
+  @@map("accounts")
+}
+
+model Session {
+  id           String   @id @default(cuid())
+  sessionToken String   @unique @map("session_token")
+  userId       String   @map("user_id")
+  expires      DateTime
+
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("sessions")
+}
+
+model User {
+  id            String    @id @default(cuid())
+  name          String?
+  email         String?   @unique
+  emailVerified DateTime? @map("email_verified")
+  image         String?
+  accounts      Account[]
+  sessions      Session[]
+
+  @@map("users")
+}
+
+model VerificationToken {
+  identifier String
+  token      String   @unique
+  expires    DateTime
+
+  @@map("verification_tokens")
+  @@unique([identifier, token])
+}


### PR DESCRIPTION
### Purpose

This pull request migrates a Vite React application to a Next.js App Router project, establishing a backend with a MySQL database (TiDB) and setting up authentication using NextAuth.js. The goal is to create the foundational backend infrastructure for the new application architecture.

### Code changes

- **Environment Configuration (`.env`)**: Adds a new `.env` file to store the `DATABASE_URL` for the TiDB Cloud connection and placeholders for `NEXTAUTH_SECRET` and `NEXTAUTH_URL`.

- **Prisma Schema (`prisma/schema.prisma`)**: Introduces the Prisma schema configured for a MySQL provider. It defines the necessary models (`Account`, `Session`, `User`, `VerificationToken`) to support NextAuth.js authentication.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6e536f5f67914ba38c995803e45f6edd/vortex-zone)

👀 [Preview Link](https://6e536f5f67914ba38c995803e45f6edd-vortex-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6e536f5f67914ba38c995803e45f6edd</projectId>-->
<!--<branchName>vortex-zone</branchName>-->