### PR TITLE
Feat: Add protected dashboard and sign-out functionality

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,18 @@
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/lib/auth";
+import { redirect } from "next/navigation";
+
+export default async function DashboardPage() {
+  const session = await getServerSession(authOptions as any);
+
+  if (!session) {
+    redirect('/sign-in');
+  }
+
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold">Welcome to your Dashboard, {session.user?.name || session.user?.email}!</h1>
+      <p className="mt-4">This is a protected server-rendered page. Fetch and display user-specific data here.</p>
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
+    "dev": "vite",
+    "build": "vite build",
+    "start": "vite preview",
     "lint": "eslint .",
-    "preview": "next start -p 3000"
+    "preview": "vite preview -p 3000"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.11.0",

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,8 +1,10 @@
+'use client';
 import { Heart, Menu, Search, User, Bell } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Link, useLocation } from "react-router-dom";
 import { usePetContext } from "@/context/PetContext";
 import { useAuth } from "@/context/AuthContext";
+import { signOut } from "next-auth/react";
 
 type HeaderProps = { onAboutClick?: () => void };
 
@@ -75,7 +77,20 @@ const Header = ({ onAboutClick }: HeaderProps) => {
             {user ? (
               <div className="hidden sm:flex items-center space-x-3">
                 <div className="text-sm font-medium">{user.name}</div>
-                <Button variant="outline" onClick={() => logout()}>Sign Out</Button>
+                <Button
+                  variant="outline"
+                  onClick={() => {
+                    try {
+                      // clear local auth state
+                      logout();
+                    } finally {
+                      // trigger NextAuth sign out (if configured)
+                      void signOut({ callbackUrl: "/" });
+                    }
+                  }}
+                >
+                  Sign Out
+                </Button>
               </div>
             ) : (
               <Link to="/sign-in" state={{ from: location.pathname }}>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ import { componentTagger } from "lovable-tagger";
 export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
-    port: 8080,
+    port: 3000,
   },
   plugins: [
     react(),


### PR DESCRIPTION
### Purpose

Based on the conversation, the goal was to implement a complete authentication flow using NextAuth. This involved creating a protected dashboard page accessible only to authenticated users and adding a sign-out mechanism.

### Code changes

- **Protected Dashboard Route**: Added a new server component at `app/dashboard/page.tsx`. This page uses `getServerSession` to verify the user's session and redirects to the sign-in page if they are not authenticated.
- **Sign-Out Logic**: Updated the `Header.tsx` component to import and use the `signOut` function from `next-auth/react`, ensuring the user session is properly terminated on sign-out.
- **Build Script Updates**: Modified `package.json` to use `vite` for development, build, and preview scripts instead of `next`.
- **Port Configuration**: Changed the development server port in `vite.config.ts` to `3000`.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 12`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6e536f5f67914ba38c995803e45f6edd/aura-works)

👀 [Preview Link](https://6e536f5f67914ba38c995803e45f6edd-aura-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6e536f5f67914ba38c995803e45f6edd</projectId>-->
<!--<branchName>aura-works</branchName>-->